### PR TITLE
fix(meetup-link): use up-to-date link

### DIFF
--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_LOCALE = "en";
 
-export const MEETUP_LINK = "https://www.meetup.com/fccseoul/";
+export const MEETUP_LINK = "https://www.meetup.com/fccseoul/events";
 
 export const MEMBERS_API =
   "https://script.googleusercontent.com/macros/echo?user_content_key=4rN8cd-3vqsSx_DHB206g_1B1AVO0f12Ivlk0Mgez1KQd85HfKG2kUefl_7QDu0Tlhsrn1F1qTO7sRxNpsRK5L5IpA8OPdxHm5_BxDlH2jW0nuo2oDemN9CCS2h10ox_1xSncGQajx_ryfhECjZEnNblBlRDbuiG2HFvFubl-7caEodpBTwb-qB_97givsaw8M7jZj1bAmXJbSdWrc64W88rYSgSwa3ihIaY-Rq7QfHKZL93BaZN2w&lib=M2UpGi_m3xt65uFPxCT2uyKC9bJRTDmJi";


### PR DESCRIPTION
Previous link stopped working for some reason. Updated to a different one that seems to be up-to-date.

closes #59 