### PR TITLE
feat: add build step to ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+# build app to check for errors, on prs to master
+name: Build
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+      - run: yarn
+      - run: yarn build


### PR DESCRIPTION
Add build step to CI, in order to build errors before pushing to master.