### PR TITLE
#97 - Fix invalid date format on home page

### DIFF
--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_LOCALE = "en";
 
 export const MEETUP_LINK = "https://www.meetup.com/fccseoul/events";
+export const MEETUP_RSS_LINK = "https://www.meetup.com/fccseoul/events/rss/";
 
 export const MEMBERS_API =
   "https://script.googleusercontent.com/macros/echo?user_content_key=4rN8cd-3vqsSx_DHB206g_1B1AVO0f12Ivlk0Mgez1KQd85HfKG2kUefl_7QDu0Tlhsrn1F1qTO7sRxNpsRK5L5IpA8OPdxHm5_BxDlH2jW0nuo2oDemN9CCS2h10ox_1xSncGQajx_ryfhECjZEnNblBlRDbuiG2HFvFubl-7caEodpBTwb-qB_97givsaw8M7jZj1bAmXJbSdWrc64W88rYSgSwa3ihIaY-Rq7QfHKZL93BaZN2w&lib=M2UpGi_m3xt65uFPxCT2uyKC9bJRTDmJi";

--- a/src/services/meetup/index.ts
+++ b/src/services/meetup/index.ts
@@ -3,15 +3,18 @@ import { MEETUP_RSS_LINK } from "@/const";
 export const getMeetupInfo = async () => {
   const meetupResponse = await fetch(MEETUP_RSS_LINK, { cache: "no-store" });
   const meetupText = await meetupResponse.text();
-  // create an array with all the time elements with the class "text-[#00829B] text-sm font-medium uppercase"
-  const eventList = meetupText.match(
-    /<time class="text-\[#00829B\] text-sm font-medium uppercase">(.*?)<\/time>/g
-  );
+  // create an array with all the meetup times from the RSS feed"
+  const eventList = meetupText.match(/<p>Sunday.+PM<\/p>/g);
 
   // remove the html tags and timezone from the array
   const trimmedEventList = eventList?.map((event) => {
     return event.replace(/(<([^>]+)>)/gi, "").replace(/(KST)/gi, "");
   });
 
-  return trimmedEventList;
+  const correctFormatEventList = trimmedEventList?.map((badFormatEventTime) =>
+    // replace "at" with "2024" to make the date valid JS date format
+    badFormatEventTime.replace("at", "2024")
+  );
+
+  return correctFormatEventList;
 };

--- a/src/services/meetup/index.ts
+++ b/src/services/meetup/index.ts
@@ -1,7 +1,7 @@
-import { MEETUP_LINK } from "@/const";
+import { MEETUP_RSS_LINK } from "@/const";
 
 export const getMeetupInfo = async () => {
-  const meetupResponse = await fetch(MEETUP_LINK, { cache: "no-store" });
+  const meetupResponse = await fetch(MEETUP_RSS_LINK, { cache: "no-store" });
   const meetupText = await meetupResponse.text();
   // create an array with all the time elements with the class "text-[#00829B] text-sm font-medium uppercase"
   const eventList = meetupText.match(

--- a/src/services/meetup/index.ts
+++ b/src/services/meetup/index.ts
@@ -4,7 +4,7 @@ export const getMeetupInfo = async () => {
   const meetupResponse = await fetch(MEETUP_RSS_LINK, { cache: "no-store" });
   const meetupText = await meetupResponse.text();
   // create an array with all the meetup times from the RSS feed"
-  const eventList = meetupText.match(/<p>Sunday.+PM<\/p>/g);
+  const eventList = meetupText.match(/<p>Sunday.+M<\/p>/g);
 
   // remove the html tags and timezone from the array
   const trimmedEventList = eventList?.map((event) => {


### PR DESCRIPTION
Fixed a bug with the next event's date.

- Replaced the meetup link with the RSS feed for events - this returned much less text and required a much simpler RegEx to find the correct times.

Closes #97 

| Before | After |
|--|--|
| <img width="836" alt="image" src="https://github.com/user-attachments/assets/d5cc37d2-254b-4eca-ad60-63df901a9c26"> | <img width="836" alt="image" src="https://github.com/user-attachments/assets/729af932-4383-4734-8f67-ba1b5a29e1b8"> |


