### PR TITLE
Fix: next meetup date

### DIFF
--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -1,7 +1,6 @@
 export const DEFAULT_LOCALE = "en";
 
 export const MEETUP_LINK = "https://www.meetup.com/fccseoul/events";
-export const MEETUP_RSS_LINK = "https://www.meetup.com/fccseoul/events/rss/";
 
 export const MEMBERS_API =
   "https://script.googleusercontent.com/macros/echo?user_content_key=4rN8cd-3vqsSx_DHB206g_1B1AVO0f12Ivlk0Mgez1KQd85HfKG2kUefl_7QDu0Tlhsrn1F1qTO7sRxNpsRK5L5IpA8OPdxHm5_BxDlH2jW0nuo2oDemN9CCS2h10ox_1xSncGQajx_ryfhECjZEnNblBlRDbuiG2HFvFubl-7caEodpBTwb-qB_97givsaw8M7jZj1bAmXJbSdWrc64W88rYSgSwa3ihIaY-Rq7QfHKZL93BaZN2w&lib=M2UpGi_m3xt65uFPxCT2uyKC9bJRTDmJi";

--- a/src/services/meetup/index.ts
+++ b/src/services/meetup/index.ts
@@ -1,20 +1,16 @@
-import { MEETUP_RSS_LINK } from "@/const";
+import { MEETUP_LINK } from "@/const";
 
 export const getMeetupInfo = async () => {
-  const meetupResponse = await fetch(MEETUP_RSS_LINK, { cache: "no-store" });
+  const meetupResponse = await fetch(MEETUP_LINK, { cache: "no-store" });
   const meetupText = await meetupResponse.text();
-  // create an array with all the meetup times from the RSS feed"
-  const eventList = meetupText.match(/<p>Sunday.+M<\/p>/g);
 
-  // remove the html tags and timezone from the array
-  const trimmedEventList = eventList?.map((event) => {
-    return event.replace(/(<([^>]+)>)/gi, "").replace(/(KST)/gi, "");
+  // Event time format is '"dateTime":"2025-02-09T12:00:00+09:00"'
+  const eventList = meetupText.match(/"dateTime":".+?"/g);
+
+  // Format the times to '2025-02-09T12:00:00+09:00'
+  const correctFormatEventList = eventList?.map((event) => {
+    return event.replace(/"dateTime":"|"/gi, "");
   });
-
-  const correctFormatEventList = trimmedEventList?.map((badFormatEventTime) =>
-    // replace "at" with "2024" to make the date valid JS date format
-    badFormatEventTime.replace("at", "2024")
-  );
 
   return correctFormatEventList;
 };


### PR DESCRIPTION
Meetup changed the response for their RSS feed, which broke the next meetup date shown in the UI. This PR uses the old meetup link and the `dateTime` property, which seems reasonable and hopefully stable 🤞 

Current

<img width="864" alt="image" src="https://github.com/user-attachments/assets/5758d3d9-ce9d-40f9-b80e-896f07fa9d5e" />


Fix

<img width="864" alt="image" src="https://github.com/user-attachments/assets/5250680c-184f-4413-9b09-223eea156b48" />
